### PR TITLE
sass:dev was not defined as a grunt task, instead we use sass grunt task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -455,7 +455,7 @@ module.exports = function (grunt) {
     'concatFontStyle',
     'swig:dev',
     'babelAndAppend',
-    'sass:dev',
+    'sass',
     'open:dev',
     'concurrent:devWatch'
   ]);


### PR DESCRIPTION
This project doesn't run out of the box on windows boxes.

If you want to test it on a windows machine , first of all you have to have installed some pre-requirements:

- Ruby , Sass , python ( I've forgot exactly at which point of installation was required, tip : node-gyp modules) . Take a look  to some [prerequisites on Windows boxes](https://github.com/nodejs/node-gyp#on-windows)

- livereload has to be install globally. 

```javascript
npm install -g livereload
```
Hope it helps! :-)


